### PR TITLE
Reimplementing jsCaTs as a self-invoking function; fixing syntax error

### DIFF
--- a/html/interface.html
+++ b/html/interface.html
@@ -12,7 +12,6 @@
     .clear{
        clear:both;}
     </style>   
-    <script type = "text/javascript" src = "javascript/jsCaTS.js"></script>
     <script type = "text/javascript" src = "javascript/nouislider.js"></script>
     <script type = "text/javascript" src = "javascript/wNumbUpdated6_21_15.js"></script>
 
@@ -125,5 +124,6 @@
 </div>
 
 </body>
+<script type = "text/javascript" src = "javascript/jsCaTS.js"></script>
 <!--#include file="bottom.inc"-->
 </html>

--- a/javascript/jsCaTS.js
+++ b/javascript/jsCaTS.js
@@ -1,4 +1,4 @@
-$(document).ready(function(){
+(function(){
 
             var cases_slider = document.getElementById('cases_slider');
             noUiSlider.create(cases_slider, {
@@ -10,7 +10,7 @@ $(document).ready(function(){
                 'min':100, 
                 '30%':1000,
                 '70%':10000,                  
-                'max':100000)
+                'max':100000
               },
               format: wNumb({
                 decimals:0
@@ -133,7 +133,7 @@ $(document).ready(function(){
               rr_slider.noUiSlider.set(this.value);
             });
 
-    });
+})();
 
 
 


### PR DESCRIPTION
This commit does two things:
## The syntax error

Removed an extra close paren on `javascript/jsCaTS.js` line 13 (this was breaking execution). Developer tools on Chrome was able to immediately identify this error.
## The main function in jsCaTs

Refactored the main function on `javascript/jsCaTS.js` to be a self-invoking function definition instead of using jQuery's `$(document).ready(function(){...}` syntax. Since jQuery is not present as a dependency for this application this is another reason why it was breaking. It's also not worth including a library as big as jQuery for just that one feature, so this new approach keeps all that main logic in a single function definition but does so by making it self-invoking:

``` javascript
(function(){
  ...
})();
```

...essentially this executes immediately. In order to make that work as expected (i.e. execute when the DOM elements it operates on are ready) I moved the inclusion of `javascript/jsCaTS.js` to the _bottom_ of `interface.html`, right before the close body tag. This should always work, since HTML documents (including CSS and javascript includes) are loaded top-to-bottom in a blocking fashion, such that the item on the next line won't load until the item on this line is loaded. 
